### PR TITLE
Correct metadata export warnings

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -6,15 +6,11 @@ import { Toaster } from 'react-hot-toast'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata = {
+  metadataBase: new URL(process.env.NODE_ENV === 'production' ? 'https://tempmail.example.com' : 'http://localhost:3000'),
   title: 'TempMail - Gestion d\'emails temporaires',
   description: 'Application de gestion d\'emails temporaires sécurisée avec interface moderne',
   keywords: 'email temporaire, temp mail, email jetable, sécurité, privacy',
   authors: [{ name: 'TempMail Team' }],
-  viewport: 'width=device-width, initial-scale=1',
-  themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
-    { media: '(prefers-color-scheme: dark)', color: '#171717' }
-  ],
   manifest: '/manifest.json',
   icons: {
     icon: '/favicon.ico',
@@ -31,6 +27,15 @@ export const metadata = {
     title: 'TempMail - Gestion d\'emails temporaires',
     description: 'Application de gestion d\'emails temporaires sécurisée',
   },
+}
+
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: '#171717' }
+  ],
 }
 
 export default function RootLayout({ children }) {


### PR DESCRIPTION
Warnings were addressed by modifying `app/layout.js`.

*   The `viewport` and `themeColor` properties were moved from the `metadata` export to a new, separate `viewport` export.
    *   This aligns with Next.js 13  conventions for handling viewport-related metadata.
*   A `metadataBase` property was added to the `metadata` export.
    *   It is conditionally set to `https://tempmail.example.com` for production and `http://localhost:3000` for development.
    *   This resolves warnings regarding the base URL for social open graph and Twitter images.

These changes ensure compliance with Next.js metadata conventions, eliminating the reported warnings upon application launch.