### PR TITLE
Fix email inbox creation errors

### DIFF
--- a/lib/tempmail-api.js
+++ b/lib/tempmail-api.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
 // Configuration de l'API Temp-Mail via RapidAPI
-const RAPIDAPI_KEY = process.env.RAPIDAPI_KEY
-const RAPIDAPI_HOST = process.env.RAPIDAPI_HOST
+const RAPIDAPI_KEY = process.env.NEXT_PUBLIC_RAPIDAPI_KEY
+const RAPIDAPI_HOST = process.env.NEXT_PUBLIC_RAPIDAPI_HOST
 const BASE_URL = `https://${RAPIDAPI_HOST}`
 
 // Headers communs pour toutes les requêtes


### PR DESCRIPTION
The `TempMail API Error` and `https://undefined/` URL in console logs indicated an issue with environment variable access.

The problem stemmed from `process.env.RAPIDAPI_KEY` and `process.env.RAPIDAPI_HOST` not being accessible client-side in a Next.js application, causing the API base URL to resolve to `undefined`.

To resolve this:
*   A `.env.local` file was created to define public environment variables.
*   The variables were prefixed with `NEXT_PUBLIC_` (e.g., `NEXT_PUBLIC_RAPIDAPI_KEY`, `NEXT_PUBLIC_RAPIDAPI_HOST`) to make them available in the browser.
*   `lib/tempmail-api.js` was updated to reference these new `NEXT_PUBLIC_` prefixed variables.
*   The development server was restarted to load the new environment variables.

This ensures the API calls in `lib/tempmail-api.js` will correctly use the RapidAPI host and key, resolving the `ERR_NAME_NOT_RESOLVED` and "Aucun domaine disponible" errors once a valid API key is provided in `.env.local`.